### PR TITLE
Add --users when bind mounting 

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,4 @@ Hi Crazybus! You've successfully authenticated, but GitHub does not provide shel
 * Add command line flags
 * Mount the docker socket into the container
 * Automated ssh agent forwarding for OSX. https://github.com/uber-common/docker-ssh-agent-forward
+* Run as current user and group when bind mounting

--- a/lope_test.go
+++ b/lope_test.go
@@ -364,3 +364,38 @@ func TestCreateDockerfile(t *testing.T) {
 		})
 	}
 }
+
+func TestUserAndGroupParams(t *testing.T) {
+
+	var tests = []struct {
+		description string
+		mount       bool
+		want        string
+	}{
+		{
+			"--users is NOT set if mount is false",
+			false,
+			"",
+		},
+		{
+			"--users IS set if mount is true",
+			true,
+			fmt.Sprintf("--user="),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			l.params = make([]string, 0)
+			l.cfg.mount = test.mount
+			l.addUserAndGroup()
+
+			got := strings.Join(l.params, " ")
+			want := test.want
+
+			if !strings.HasPrefix(got, want) {
+				t.Errorf("got %q wanted prefix: %q", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
So we don't run into weird permission errors where docker creates files owned by root in your current
directory.

```
❯ lope -noMount alpine id -u
0
❯ lope -addMount alpine id -u
0
❯ lope alpine id -u
501
```