### PR TITLE
Add some real world examples to show that lope is actually useful. 

### DIFF
--- a/lope_test.go
+++ b/lope_test.go
@@ -15,6 +15,7 @@ var c = &config{
 	home:         "/home/lope",
 	image:        "lopeImage",
 	instructions: []string{""},
+	workDir:      "/lope",
 	paths: []string{
 		path(".vault-token"),
 		path(".aws/"),
@@ -122,7 +123,7 @@ func TestAddVolumes(t *testing.T) {
 			false,
 			false,
 			"/home/user/pro/lope/",
-			"-v /home/user/pro/lope/:/lope/",
+			"-v /home/user/pro/lope/:/lope",
 		},
 		{
 			"Add multiple directories",
@@ -266,7 +267,7 @@ func TestDefaultParams(t *testing.T) {
 		{
 			"Override the entrypoint",
 			"/bin/ohyeah",
-			"docker run --rm --entrypoint /bin/ohyeah -w /lope",
+			"docker run --rm --interactive --entrypoint /bin/ohyeah --workdir /lope --net host",
 		},
 	}
 


### PR DESCRIPTION
* Add an option to inject the docker client into the image
* Invert the logic for -docker flag to -noDocker for when you don't want
to mount the docker socket
* Add support for attaching directly to a container for an interactive
session
* Add `--tty`, `--interative` and `--net host` as default run parameters
* Add `TMPDIR` to the default blacklist of envionment variables. This path
was referring to an OSX path that may (most likely) will not exist in the container
* Add some more complex real world examples
* Add an option to override the default working directory