### PR TITLE
Don't add the value for the environment variable to the run command

### DIFF
--- a/lope.go
+++ b/lope.go
@@ -211,7 +211,7 @@ func (l *lope) addEnvVars() {
 			}
 		}
 		if add && !blacklisted {
-			l.params = append(l.params, "-e", e)
+			l.params = append(l.params, "-e", name)
 		}
 	}
 	if l.cfg.ssh {
@@ -389,7 +389,7 @@ func (l *lope) commandProxy() {
 
 	l.params = append(l.params, "--add-host=localhost:"+ip)
 
-	l.envs = append(l.envs, "LOPE_PROXY_ADDR=http://"+ip+":"+l.cfg.cmdProxyPort)
+	l.params = append(l.params, "-e", "LOPE_PROXY_ADDR=http://"+ip+":"+l.cfg.cmdProxyPort)
 }
 
 func debug(message string) {

--- a/lope_test.go
+++ b/lope_test.go
@@ -195,7 +195,7 @@ func TestAddEnvVars(t *testing.T) {
 			[]string{},
 			[]string{},
 			false,
-			"-e ENV1=hello1",
+			"-e ENV1",
 		},
 		{
 			"Add multiple env vars",
@@ -203,7 +203,7 @@ func TestAddEnvVars(t *testing.T) {
 			[]string{},
 			[]string{},
 			false,
-			"-e ENV1=hello1 -e ENV2=hello2",
+			"-e ENV1 -e ENV2",
 		},
 		{
 			"Blacklist an env var",
@@ -219,7 +219,7 @@ func TestAddEnvVars(t *testing.T) {
 			[]string{},
 			[]string{"ENV"},
 			false,
-			"-e ENV1=hello1 -e ENV2=hello2",
+			"-e ENV1 -e ENV2",
 		},
 		{
 			"Blacklist and whitelisting env vars",
@@ -227,7 +227,7 @@ func TestAddEnvVars(t *testing.T) {
 			[]string{"ENV1"},
 			[]string{"ENV"},
 			false,
-			"-e ENV2=hello2",
+			"-e ENV2",
 		},
 		{
 			"Add the SSH auth socket if ssh is enabled",
@@ -532,7 +532,7 @@ func TestCommandProxy(t *testing.T) {
 
 			got := ""
 			want := test.want
-			for _, e := range l.envs {
+			for _, e := range l.params {
 				split := strings.Split(e, "=")
 				if split[0] == "LOPE_PROXY_ADDR" {
 					addr, err := url.Parse(split[1])


### PR DESCRIPTION
This isn't needed since Docker will automatically pass through the
value. Leaving this out means that the value of an environment variable
is not unnecessarily exposed